### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,4 +1,6 @@
 name: Pre-commit
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jrheard/annotation_prioritizer/security/code-scanning/1](https://github.com/jrheard/annotation_prioritizer/security/code-scanning/1)

The best way to fix this problem is to add a `permissions` block to explicitly restrict the GitHub Actions job's access. Since the steps described in the workflow (checking out code, installing dependencies, running pre-commit) only need to read the repository contents and do not require write access, you should explicitly set `permissions: contents: read`. This can be set either at the root of the workflow (to apply to all jobs) or at the job level (to apply only to the `pre-commit` job). The simplest and safest approach is to add the following at the top level of the YAML file, right below `name: Pre-commit` and before `on:`.

No additional methods, imports, or dependencies are required for this change; it is a simple YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
