### PR TITLE
feat: introduce QualifiedName type for type-safe qualified names

### DIFF
--- a/.claude/commands/work-on-plan.md
+++ b/.claude/commands/work-on-plan.md
@@ -2,6 +2,7 @@ Find the next pending commit in the implementation plan that's ready to be worke
 Implement that commit completely, including all code and tests.
 Implement ONLY that one commit, don't move on to the next commits after that.
 BEFORE committing your changes, update the plan file to mark the task as completed and reflect any progress made.
+If you've completed the last commit in the plan file, move the file from the pending/ directory to the completed/ directory.
 You should only be making ONE commit, and ALL of your changes (including updating the plan doc) should be in that commit.
 Use the sequential thinking tool.
 

--- a/.claude/commands/work-on-plan.md
+++ b/.claude/commands/work-on-plan.md
@@ -1,8 +1,8 @@
 Find the next pending commit in the implementation plan that's ready to be worked on.
 Implement that commit completely, including all code and tests.
 Implement ONLY that one commit, don't move on to the next commits after that.
-Before committing your changes, update the plan file to mark the task as completed and reflect any progress made.
-Create a commit with the changes using conventional commit format.
+BEFORE committing your changes, update the plan file to mark the task as completed and reflect any progress made.
+You should only be making ONE commit, and ALL of your changes (including updating the plan doc) should be in that commit.
 Use the sequential thinking tool.
 
 <plan file>

--- a/.claude/commands/work-on-plan.md
+++ b/.claude/commands/work-on-plan.md
@@ -1,1 +1,6 @@
-Find the next pending commit in the $ARGUMENTS implementation plan that's ready to be worked on. Implement that commit completely, including all code and tests. Implement ONLY that one commit, don't move on to the next commits after that. Update the plan file to mark the task as completed and reflect any progress made.  Create a commit with the changes using conventional commit format. Use the sequential thinking tool.
+Find the next pending commit in the $ARGUMENTS implementation plan that's ready to be worked on.
+Implement that commit completely, including all code and tests.
+Implement ONLY that one commit, don't move on to the next commits after that.
+Before committing your changes, update the plan file to mark the task as completed and reflect any progress made.
+Create a commit with the changes using conventional commit format.
+Use the sequential thinking tool.

--- a/.claude/commands/work-on-plan.md
+++ b/.claude/commands/work-on-plan.md
@@ -1,6 +1,10 @@
-Find the next pending commit in the $ARGUMENTS implementation plan that's ready to be worked on.
+Find the next pending commit in the implementation plan that's ready to be worked on.
 Implement that commit completely, including all code and tests.
 Implement ONLY that one commit, don't move on to the next commits after that.
 Before committing your changes, update the plan file to mark the task as completed and reflect any progress made.
 Create a commit with the changes using conventional commit format.
 Use the sequential thinking tool.
+
+<plan file>
+$ARGUMENTS
+</plan file>

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,7 @@ repos:
     hooks:
       - id: pyright
         args: [--project, pyrightconfig.precommit.json]
+        pass_filenames: false
 
   - repo: local
     hooks:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ This project follows functional programming principles:
 # Documentation Updates
 
 - Keep project_status.md updated: When adding, removing, or changing features, always update `docs/project_status.md` to reflect the current state. This document serves as the authoritative source of truth for what functionality is implemented, planned, or out of scope.
-- Update implementation plans: When completing tasks from a plan document in `plans/`, update that plan to mark completed tasks and record any implementation changes or discoveries.
+- When completing tasks from a plan document in `plans/`, update that plan to mark completed tasks and record any implementation changes or discoveries.
 - NEVER edit `dev-diary.txt` - this is a personal log maintained by the user only
 - Always include changes to `dev-diary.txt` in commits (user edits this file during work)
 

--- a/dev-diary.txt
+++ b/dev-diary.txt
@@ -332,3 +332,5 @@ TODO add asserts in some places where we currently have to-dos??
 WIP QualifiedName newtype?? could be useful for prod AND test code???
 
 TODO resolve_function_call and resolve_class_name are identical
+
+TODO helper for making a qualified name from a scope stack?

--- a/dev-diary.txt
+++ b/dev-diary.txt
@@ -330,3 +330,5 @@ TODO i feel like the code in count_function_calls() is duplicated in multiple pl
 TODO add asserts in some places where we currently have to-dos??
 
 WIP QualifiedName newtype?? could be useful for prod AND test code???
+
+TODO resolve_function_call and resolve_class_name are identical

--- a/plans/completed/qualified-name-newtype-2025-09-17.md
+++ b/plans/completed/qualified-name-newtype-2025-09-17.md
@@ -380,7 +380,9 @@ def analyze_file(file_path: str) -> tuple[FunctionPriority, ...]:
 
 **Why this grouping:** All code that consumes qualified names is updated together, completing the type migration in production code.
 
-### Commit 4: Update all tests and remove obsolete runtime checks
+### Commit 4: Update all tests and remove obsolete runtime checks ✅
+
+**Status:** COMPLETED (commit d5c5ddf)
 
 **Files to modify:**
 - `tests/helpers/factories.py`

--- a/plans/pending/qualified-name-newtype-2025-09-17.md
+++ b/plans/pending/qualified-name-newtype-2025-09-17.md
@@ -164,7 +164,9 @@ class AnnotationScore:
 
 **Why this grouping:** Introducing the type and updating models together ensures the foundation is in place before we start using it elsewhere.
 
-### Commit 2: Update all qualified name producers
+### Commit 2: Update all qualified name producers ✅
+
+**Status:** COMPLETED
 
 **Files to modify:**
 - `src/annotation_prioritizer/scope_tracker.py`

--- a/plans/pending/qualified-name-newtype-2025-09-17.md
+++ b/plans/pending/qualified-name-newtype-2025-09-17.md
@@ -455,10 +455,17 @@ assert qualified_names == expected
 ## Testing Strategy
 
 Each commit should:
-1. Pass type checking with `pyright`
+1. Pass type checking with `pyright` (see note below)
 2. Pass all existing tests with `pytest`
 3. Maintain 100% test coverage
 4. Pass linting with `ruff check` and `ruff format`
+
+**IMPORTANT NOTE on pyright:**
+- After Commit 1, pyright will fail with ~72 type errors when checking the entire codebase
+- These errors are expected and indicate places where strings need to be converted to QualifiedName
+- **Use `--no-verify` flag when committing Commits 2-3** if the only type errors are from the QualifiedName migration
+- **Pyright will pass again after Commit 4** when all tests are updated
+- The pre-commit hook is configured to check the entire codebase (not just staged files) to ensure complete migration
 
 ## Key Considerations
 

--- a/plans/pending/qualified-name-newtype-2025-09-17.md
+++ b/plans/pending/qualified-name-newtype-2025-09-17.md
@@ -18,13 +18,15 @@ The codebase extensively uses qualified names (e.g., `"__module__.Calculator.add
 
 ## Implementation Steps
 
-### Commit 0: Remove builtin tracking from ClassRegistry
+### Commit 0: Remove builtin tracking from ClassRegistry ✅
+
+**Status:** COMPLETED (commit ec7e9e8)
 
 **Files to modify:**
-- `src/annotation_prioritizer/class_discovery.py`
-- `src/annotation_prioritizer/call_counter.py`
-- `tests/unit/test_class_discovery.py`
-- `tests/unit/test_call_counter.py`
+- `src/annotation_prioritizer/class_discovery.py` ✅
+- `src/annotation_prioritizer/call_counter.py` ✅
+- `tests/unit/test_class_discovery.py` ✅
+- `tests/unit/test_call_counter.py` ✅
 
 **Changes to class_discovery.py:**
 

--- a/plans/pending/qualified-name-newtype-2025-09-17.md
+++ b/plans/pending/qualified-name-newtype-2025-09-17.md
@@ -108,7 +108,9 @@ Remove all tests related to builtin classes:
 - Enables a cleaner QualifiedName implementation with a single type everywhere
 - Eliminates confusion about how to represent builtins with qualified names
 
-### Commit 1: Introduce QualifiedName type and update all data models
+### Commit 1: Introduce QualifiedName type and update all data models ✅
+
+**Status:** COMPLETED
 
 **Files to modify:**
 - `src/annotation_prioritizer/models.py`

--- a/plans/pending/qualified-name-newtype-2025-09-17.md
+++ b/plans/pending/qualified-name-newtype-2025-09-17.md
@@ -267,7 +267,9 @@ def build_class_registry(tree: ast.AST) -> ClassRegistry:
 
 **Why this grouping:** All functions that create qualified names are updated together, ensuring consistent production of the new type.
 
-### Commit 3: Update all qualified name consumers
+### Commit 3: Update all qualified name consumers ✅
+
+**Status:** COMPLETED (commit 6ac45e2)
 
 **Files to modify:**
 - `src/annotation_prioritizer/call_counter.py`

--- a/src/annotation_prioritizer/analyzer.py
+++ b/src/annotation_prioritizer/analyzer.py
@@ -47,4 +47,3 @@ def analyze_file(file_path: str) -> tuple[FunctionPriority, ...]:
 
     # 4. Sort by priority score (highest first)
     return tuple(sorted(priorities, key=lambda p: p.priority_score, reverse=True))
-# Test comment

--- a/src/annotation_prioritizer/analyzer.py
+++ b/src/annotation_prioritizer/analyzer.py
@@ -47,3 +47,4 @@ def analyze_file(file_path: str) -> tuple[FunctionPriority, ...]:
 
     # 4. Sort by priority score (highest first)
     return tuple(sorted(priorities, key=lambda p: p.priority_score, reverse=True))
+# Test comment

--- a/src/annotation_prioritizer/analyzer.py
+++ b/src/annotation_prioritizer/analyzer.py
@@ -2,7 +2,7 @@
 
 from .call_counter import count_function_calls
 from .function_parser import parse_function_definitions
-from .models import AnnotationScore, FunctionPriority
+from .models import AnnotationScore, FunctionPriority, QualifiedName
 from .scoring import calculate_annotation_score
 
 
@@ -28,7 +28,9 @@ def analyze_file(file_path: str) -> tuple[FunctionPriority, ...]:
 
     # 2. Count function calls
     call_counts = count_function_calls(file_path, function_infos)
-    call_count_map = {cc.function_qualified_name: cc.call_count for cc in call_counts}
+    call_count_map: dict[QualifiedName, int] = {
+        cc.function_qualified_name: cc.call_count for cc in call_counts
+    }
 
     # 3. Calculate annotation scores and combine into priority rankings
     priorities: list[FunctionPriority] = []

--- a/src/annotation_prioritizer/call_counter.py
+++ b/src/annotation_prioritizer/call_counter.py
@@ -260,31 +260,11 @@ class CallCountVisitor(ast.NodeVisitor):
         return None
 
     def _resolve_function_call(self, function_name: str) -> QualifiedName | None:
-        """Resolve a direct function call to its qualified name.
-
-        Tries to resolve the function call by checking different scope levels,
-        starting from more specific (nested) scopes and falling back to module level.
-        Only returns names for functions that exist in the known functions list.
-
-        Args:
-            function_name: The local name of the function being called
-
-        Returns:
-            Qualified function name if found in known functions, None otherwise
-        """
+        """Resolve a function call to its qualified name."""
         return self._resolve_name_in_scope(function_name, self.call_counts.keys())
 
     def _resolve_class_name(self, class_name: str) -> QualifiedName | None:
-        """Resolve a class name to its qualified form based on current scope.
-
-        Only resolves user-defined classes found in the AST.
-
-        Args:
-            class_name: The name to resolve (e.g., "Calculator", "Outer.Inner")
-
-        Returns:
-            Qualified class name if found in registry, None otherwise
-        """
+        """Resolve a class name to its qualified name."""
         return self._resolve_name_in_scope(class_name, self._class_registry.classes)
 
     def _resolve_name_in_scope(self, name: str, registry: Iterable[QualifiedName]) -> QualifiedName | None:

--- a/src/annotation_prioritizer/function_parser.py
+++ b/src/annotation_prioritizer/function_parser.py
@@ -37,7 +37,7 @@ import ast
 from pathlib import Path
 from typing import override
 
-from .models import FunctionInfo, ParameterInfo, Scope, ScopeKind
+from .models import FunctionInfo, ParameterInfo, QualifiedName, Scope, ScopeKind, make_qualified_name
 from .scope_tracker import ScopeStack, add_scope, create_initial_stack, drop_last_scope
 
 
@@ -272,7 +272,7 @@ class FunctionDefinitionVisitor(ast.NodeVisitor):
 
         self.functions.append(function_info)
 
-    def _build_qualified_name(self, function_name: str) -> str:
+    def _build_qualified_name(self, function_name: str) -> QualifiedName:
         """Construct a fully qualified name using the current scope context.
 
         Builds qualified names by combining all scopes in the current stack with
@@ -289,7 +289,7 @@ class FunctionDefinitionVisitor(ast.NodeVisitor):
             its complete scope hierarchy including the module scope.
         """
         scope_names = [scope.name for scope in self._scope_stack]
-        return ".".join([*scope_names, function_name])
+        return make_qualified_name(".".join([*scope_names, function_name]))
 
 
 def parse_function_definitions(file_path: str) -> tuple[FunctionInfo, ...]:

--- a/src/annotation_prioritizer/models.py
+++ b/src/annotation_prioritizer/models.py
@@ -9,6 +9,24 @@ Data Flow Through Models:
 
 from dataclasses import dataclass
 from enum import StrEnum
+from typing import NewType
+
+# Define the new type for qualified names like "__module__.ClassName.method"
+QualifiedName = NewType("QualifiedName", str)
+
+
+def make_qualified_name(name: str) -> QualifiedName:
+    """Create a QualifiedName from a string.
+
+    This is the only way to create a QualifiedName, ensuring type safety.
+
+    Args:
+        name: A qualified name string like "__module__.ClassName.method"
+
+    Returns:
+        A QualifiedName instance
+    """
+    return QualifiedName(name)
 
 
 class ScopeKind(StrEnum):
@@ -65,7 +83,9 @@ class FunctionInfo:
     """
 
     name: str  # Local function name (e.g., 'add')
-    qualified_name: str  # Full name with complete scope hierarchy (e.g., '__module__.Calculator.add')
+    qualified_name: (
+        QualifiedName  # Full name with complete scope hierarchy (e.g., '__module__.Calculator.add')
+    )
     parameters: tuple[ParameterInfo, ...]  # All parameters in definition order
     has_return_annotation: bool  # Whether return type is annotated
     line_number: int  # Line where function is defined (1-indexed)
@@ -82,7 +102,7 @@ class CallCount:
     """
 
     function_qualified_name: (
-        str  # Must match FunctionInfo.qualified_name exactly (e.g., "__module__.Calculator.add")
+        QualifiedName  # Must match FunctionInfo.qualified_name exactly (e.g., "__module__.Calculator.add")
     )
     call_count: int  # Number of resolved calls (can be 0)
 
@@ -100,7 +120,9 @@ class AnnotationScore:
         - 'self' and 'cls' parameters are excluded from scoring
     """
 
-    function_qualified_name: str  # Identifies the scored function (e.g., "__module__.Calculator.add")
+    function_qualified_name: (
+        QualifiedName  # Identifies the scored function (e.g., "__module__.Calculator.add")
+    )
     parameter_score: float  # Ratio of annotated parameters (0.0 to 1.0)
     return_score: float  # 1.0 if return annotated, 0.0 otherwise
     total_score: float  # Weighted combination (0.0 = no annotations, 1.0 = fully annotated)

--- a/src/annotation_prioritizer/scope_tracker.py
+++ b/src/annotation_prioritizer/scope_tracker.py
@@ -14,7 +14,7 @@ consistently build qualified names like "__module__.ClassName.method_name".
 """
 
 import ast
-from collections.abc import Set as AbstractSet
+from collections.abc import Iterable
 
 from annotation_prioritizer.iteration import first
 from annotation_prioritizer.models import QualifiedName, Scope, ScopeKind, make_qualified_name
@@ -173,7 +173,7 @@ def build_qualified_name(
 
 
 def find_first_match(
-    candidates: tuple[QualifiedName, ...], registry: AbstractSet[QualifiedName]
+    candidates: tuple[QualifiedName, ...], registry: Iterable[QualifiedName]
 ) -> QualifiedName | None:
     """Check candidates against a registry and return first match.
 

--- a/tests/helpers/factories.py
+++ b/tests/helpers/factories.py
@@ -9,6 +9,8 @@ from annotation_prioritizer.models import (
     FunctionInfo,
     FunctionPriority,
     ParameterInfo,
+    QualifiedName,
+    make_qualified_name,
 )
 
 
@@ -41,7 +43,7 @@ def make_parameter(
 def make_function_info(  # noqa: PLR0913
     name: str = "test_func",
     *,
-    qualified_name: str | None = None,
+    qualified_name: QualifiedName | None = None,
     parameters: tuple[ParameterInfo, ...] | None = None,
     has_return_annotation: bool = False,
     line_number: int = 1,
@@ -65,7 +67,7 @@ def make_function_info(  # noqa: PLR0913
         assert "." not in name, (
             f"Function name should not be qualified when qualified_name is not provided, got: {name}"
         )
-        qualified_name = f"__module__.{name}"
+        qualified_name = make_qualified_name(f"__module__.{name}")
     if parameters is None:
         parameters = ()
 
@@ -119,7 +121,7 @@ def make_priority(  # noqa: PLR0913
         f"Inconsistent return annotation state: return_score={return_score}, "
         f"has_return_annotation={has_return_annotation}"
     )
-    qualified_name = f"__module__.{name}"
+    qualified_name = make_qualified_name(f"__module__.{name}")
     if parameters is None:
         parameters = ()
 

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -1,6 +1,7 @@
 """End-to-end integration tests for the type annotation prioritizer."""
 
 from annotation_prioritizer.analyzer import analyze_file
+from annotation_prioritizer.models import make_qualified_name
 from tests.helpers.temp_files import temp_python_file
 
 
@@ -145,19 +146,19 @@ def use_calculator():
         # Find the method with highest priority (most calls, least annotated)
         priorities_by_name = {p.function_info.qualified_name: p for p in priorities}
 
-        subtract = priorities_by_name["__module__.Calculator.subtract"]
+        subtract = priorities_by_name[make_qualified_name("__module__.Calculator.subtract")]
         # self is ignored, x and y are unannotated, return is unannotated
         # parameter_score = 0/2, return_score = 0.0, total = 0.75 * 0 + 0.25 * 0 = 0.0
         assert subtract.annotation_score.total_score == 0.0
         assert subtract.call_count == 1
 
-        multiply = priorities_by_name["__module__.Calculator.multiply"]
+        multiply = priorities_by_name[make_qualified_name("__module__.Calculator.multiply")]
         # self is ignored, x is annotated, y is unannotated, return is annotated
         # parameter_score = 1/2, return_score = 1.0, total = 0.75 * 0.5 + 0.25 * 1.0 = 0.625
         assert multiply.annotation_score.total_score == 0.625
         assert multiply.call_count == 1
 
-        add = priorities_by_name["__module__.Calculator.add"]
+        add = priorities_by_name[make_qualified_name("__module__.Calculator.add")]
         # self is ignored, x and y are annotated, return is annotated
         # parameter_score = 2/2, return_score = 1.0, total = 0.75 * 1.0 + 0.25 * 1.0 = 1.0
         assert add.annotation_score.total_score == 1.0

--- a/tests/unit/test_function_parser.py
+++ b/tests/unit/test_function_parser.py
@@ -3,7 +3,7 @@
 import pytest
 
 from annotation_prioritizer.function_parser import parse_function_definitions
-from annotation_prioritizer.models import ParameterInfo
+from annotation_prioritizer.models import ParameterInfo, make_qualified_name
 from tests.helpers.temp_files import temp_python_file
 
 
@@ -40,7 +40,7 @@ def simple_function(a, b):
 
         func = result[0]
         assert func.name == "simple_function"
-        assert func.qualified_name == "__module__.simple_function"
+        assert func.qualified_name == make_qualified_name("__module__.simple_function")
         assert func.has_return_annotation is False
         assert func.line_number == 2
         assert func.file_path == path
@@ -145,18 +145,18 @@ class TestClass:
 
         # Check qualified names
         instance_method = next(f for f in result if f.name == "instance_method")
-        assert instance_method.qualified_name == "__module__.TestClass.instance_method"
+        assert instance_method.qualified_name == make_qualified_name("__module__.TestClass.instance_method")
         assert instance_method.has_return_annotation is True
         assert len(instance_method.parameters) == 2
         assert instance_method.parameters[0] == ParameterInfo("self", False, False, False)
         assert instance_method.parameters[1] == ParameterInfo("x", True, False, False)
 
         class_method = next(f for f in result if f.name == "class_method")
-        assert class_method.qualified_name == "__module__.TestClass.class_method"
+        assert class_method.qualified_name == make_qualified_name("__module__.TestClass.class_method")
         assert class_method.has_return_annotation is True
 
         static_method = next(f for f in result if f.name == "static_method")
-        assert static_method.qualified_name == "__module__.TestClass.static_method"
+        assert static_method.qualified_name == make_qualified_name("__module__.TestClass.static_method")
         assert static_method.has_return_annotation is False
 
 
@@ -177,10 +177,12 @@ class OuterClass:
         assert len(result) == 2
 
         outer_method = next(f for f in result if f.name == "outer_method")
-        assert outer_method.qualified_name == "__module__.OuterClass.outer_method"
+        assert outer_method.qualified_name == make_qualified_name("__module__.OuterClass.outer_method")
 
         inner_method = next(f for f in result if f.name == "inner_method")
-        assert inner_method.qualified_name == "__module__.OuterClass.InnerClass.inner_method"
+        assert inner_method.qualified_name == make_qualified_name(
+            "__module__.OuterClass.InnerClass.inner_method"
+        )
 
 
 def test_parse_async_functions() -> None:
@@ -199,11 +201,11 @@ class AsyncClass:
         assert len(result) == 2
 
         async_func = next(f for f in result if f.name == "async_function")
-        assert async_func.qualified_name == "__module__.async_function"
+        assert async_func.qualified_name == make_qualified_name("__module__.async_function")
         assert async_func.has_return_annotation is True
 
         async_method = next(f for f in result if f.name == "async_method")
-        assert async_method.qualified_name == "__module__.AsyncClass.async_method"
+        assert async_method.qualified_name == make_qualified_name("__module__.AsyncClass.async_method")
         assert async_method.has_return_annotation is False
 
 
@@ -306,15 +308,15 @@ def outer_function(x):
 
         # Verify specific function details
         outer_func = next(f for f in result if f.name == "outer_function")
-        assert outer_func.qualified_name == "__module__.outer_function"
+        assert outer_func.qualified_name == make_qualified_name("__module__.outer_function")
         assert outer_func.has_return_annotation is False
 
         inner_func = next(f for f in result if f.name == "inner_function")
-        assert inner_func.qualified_name == "__module__.outer_function.inner_function"
+        assert inner_func.qualified_name == make_qualified_name("__module__.outer_function.inner_function")
         assert inner_func.has_return_annotation is False
 
         another_inner = next(f for f in result if f.name == "another_inner")
-        assert another_inner.qualified_name == "__module__.outer_function.another_inner"
+        assert another_inner.qualified_name == make_qualified_name("__module__.outer_function.another_inner")
         assert another_inner.has_return_annotation is True
 
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,0 +1,32 @@
+"""Tests for the models module, including QualifiedName type."""
+
+from annotation_prioritizer.models import make_qualified_name
+
+
+def test_make_qualified_name() -> None:
+    """Test creating QualifiedName instances."""
+    # Test simple module-level function
+    name = make_qualified_name("__module__.function")
+    assert isinstance(name, str)  # At runtime, it's a string
+    assert name == "__module__.function"
+
+    # Test class method
+    class_method = make_qualified_name("__module__.ClassName.method")
+    assert class_method == "__module__.ClassName.method"
+
+    # Test nested class method
+    nested = make_qualified_name("__module__.Outer.Inner.method")
+    assert nested == "__module__.Outer.Inner.method"
+
+    # Test that QualifiedName is hashable and can be used in sets/dicts
+    names = {
+        make_qualified_name("__module__.foo"),
+        make_qualified_name("__module__.bar"),
+    }
+    assert len(names) == 2
+
+    # Test that identical names are equal
+    name1 = make_qualified_name("__module__.test")
+    name2 = make_qualified_name("__module__.test")
+    assert name1 == name2
+    assert hash(name1) == hash(name2)

--- a/tests/unit/test_scope_tracker.py
+++ b/tests/unit/test_scope_tracker.py
@@ -8,7 +8,7 @@ import ast
 
 import pytest
 
-from annotation_prioritizer.models import Scope, ScopeKind
+from annotation_prioritizer.models import QualifiedName, Scope, ScopeKind, make_qualified_name
 from annotation_prioritizer.scope_tracker import (
     add_scope,
     build_qualified_name,
@@ -270,19 +270,29 @@ def test_build_qualified_name_exclude_classes() -> None:
 def test_find_first_match_found() -> None:
     """Test find_first_match when a match is found."""
     candidates = (
-        "__module__.Outer.Inner.method",
-        "__module__.Outer.method",
-        "__module__.method",
+        make_qualified_name("__module__.Outer.Inner.method"),
+        make_qualified_name("__module__.Outer.method"),
+        make_qualified_name("__module__.method"),
     )
-    registry = frozenset({"__module__.Outer.method", "__module__.other_func"})
+    registry = frozenset(
+        {
+            make_qualified_name("__module__.Outer.method"),
+            make_qualified_name("__module__.other_func"),
+        }
+    )
     result = find_first_match(candidates, registry)
-    assert result == "__module__.Outer.method"
+    assert result == make_qualified_name("__module__.Outer.method")
 
 
 def test_find_first_match_not_found() -> None:
     """Test find_first_match when no match is found."""
-    candidates = ("__module__.unknown", "__module__.missing")
-    registry = frozenset({"__module__.existing", "__module__.other"})
+    candidates = (make_qualified_name("__module__.unknown"), make_qualified_name("__module__.missing"))
+    registry = frozenset(
+        {
+            make_qualified_name("__module__.existing"),
+            make_qualified_name("__module__.other"),
+        }
+    )
     result = find_first_match(candidates, registry)
     assert result is None
 
@@ -290,15 +300,15 @@ def test_find_first_match_not_found() -> None:
 def test_find_first_match_empty_candidates() -> None:
     """Test find_first_match with empty candidates."""
     candidates = ()
-    registry = frozenset({"__module__.func"})
+    registry = frozenset({make_qualified_name("__module__.func")})
     result = find_first_match(candidates, registry)
     assert result is None
 
 
 def test_find_first_match_empty_registry() -> None:
     """Test find_first_match with empty registry."""
-    candidates = ("__module__.func",)
-    registry: frozenset[str] = frozenset()
+    candidates = (make_qualified_name("__module__.func"),)
+    registry: frozenset[QualifiedName] = frozenset()
     result = find_first_match(candidates, registry)
     assert result is None
 

--- a/tests/unit/test_scoring.py
+++ b/tests/unit/test_scoring.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from annotation_prioritizer.models import ParameterInfo
+from annotation_prioritizer.models import ParameterInfo, make_qualified_name
 from annotation_prioritizer.scoring import (
     PARAMETERS_WEIGHT,
     RETURN_TYPE_WEIGHT,
@@ -223,7 +223,7 @@ def test_complex_parameter_mix() -> None:
     """Test scoring with a complex mix of parameter types."""
     function_info = make_function_info(
         "complex_func",
-        qualified_name="__module__.ClassName.complex_func",
+        qualified_name=make_qualified_name("__module__.ClassName.complex_func"),
         parameters=(
             make_parameter("self"),
             make_parameter("a", annotated=True),


### PR DESCRIPTION
## Summary
- Introduces `QualifiedName` NewType to distinguish qualified names from regular strings throughout the codebase
- Removes builtin class tracking from `ClassRegistry` since we never count calls to builtin methods
- Provides compile-time type safety for function qualified names, preventing mixing of simple and qualified name strings

## Changes

### Type Safety Improvements
- Added `QualifiedName` NewType in `models.py` with `make_qualified_name()` helper function
- Updated all data models (`FunctionInfo`, `CallCount`, `AnnotationScore`) to use `QualifiedName` instead of `str`
- Modified all functions that produce or consume qualified names to use the new type

### Simplified Class Registry
- Removed tracking of Python builtin types from `ClassRegistry` 
- Now only tracks user-defined classes found in the AST
- Eliminates confusion about how to represent builtins with qualified names

### Migration Details
The implementation was done in 4 systematic commits:
1. Remove builtin tracking from ClassRegistry (48d64b4)
2. Introduce QualifiedName type and update data models (8dd9d60)
3. Update all qualified name producers (a3539f4, a12dde9)
4. Update all qualified name consumers and tests (aa2d641, a89cd52, cda9709)

## Benefits
- **Compile-time safety**: Type checker catches mixing of simple and qualified names
- **Self-documenting code**: Function signatures clearly indicate expected name types  
- **Reduced runtime checks**: Type system enforces constraints previously checked at runtime
- **Better IDE support**: Auto-completion and type hints work correctly
- **Simpler codebase**: No special cases for builtin types

## Test plan
- [x] All existing tests pass
- [x] Type checking passes with pyright in strict mode
- [x] 100% test coverage maintained
- [x] Linting passes with ruff

🤖 Generated with [Claude Code](https://claude.ai/code)